### PR TITLE
Use upstream io_bazel gogoslick rule

### DIFF
--- a/language/go/generate.go
+++ b/language/go/generate.go
@@ -442,9 +442,9 @@ func (g *generator) generateProto(mode proto.Mode, target protoTarget, importPat
 	goProtoLibrary.SetAttr("proto", ":"+protoName)
 	g.setImportAttrs(goProtoLibrary, importPath)
 	if target.hasServices {
-		goProtoLibrary.SetAttr("compilers", []string{"//:gogo_slick", "//:go_yarpc"})
+		goProtoLibrary.SetAttr("compilers", []string{"@io_bazel_rules_go//proto:gogoslick_grpc", "//:go_yarpc"})
 	} else {
-		goProtoLibrary.SetAttr("compilers", []string{"//:gogo_slick"})
+		goProtoLibrary.SetAttr("compilers", []string{"@io_bazel_rules_go//proto:gogoslick_grpc"})
 	}
 	if g.shouldSetVisibility {
 		goProtoLibrary.SetAttr("visibility", visibility)

--- a/language/go/kinds.go
+++ b/language/go/kinds.go
@@ -78,6 +78,7 @@ var goKinds = map[string]rule.KindInfo{
 			"copts":      true,
 			"embed":      true,
 			"proto":      true,
+			"compilers":	true,
 		},
 		ResolveAttrs: map[string]bool{"deps": true},
 	},


### PR DESCRIPTION
Now with https://github.com/bazelbuild/rules_go/pull/1923 merged into master, we can use the upstream version of the gogoslick rule.

We can remove the hard-coded compilers once the PR for Gazelle supporting custom compilers is complete.